### PR TITLE
Add 'continueOnError' option to prevent gulp from stopping on error

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,13 @@ Example:
 
 ```
 
+#### options.continueOnError
+Type: `Boolean`
+Default: `undefined`
+
+Use along with `gulp.watch` to prevent gulp from stopping if there is an error
+while compiling your files. Errors are still logged to the console.
+
 ## LICENSE
 
 (MIT License)

--- a/index.js
+++ b/index.js
@@ -53,7 +53,13 @@ module.exports = function (options) {
     }
 
     s.render(function(err, css){
-      if (err) return cb(err);
+      if (err) {
+        if (options.continueOnError) {
+          gutil.log('[gulp-stylus] ' + gutil.colors.red(err));
+          return cb();
+        }
+        return cb(new gutil.PluginError('gulp-stylus', err));
+      }
 
       file.path = gutil.replaceExtension(file.path, '.css');
       file.contents = new Buffer(css);


### PR DESCRIPTION
Currently if there is an error in your Stylus file, the build process will stop and you'll have to restart it once you fix the problem in your stylesheet. This option will log the error to the console, but allow the process to continue, reaching `gulp.watch` if you have it set up, so that you can simply fix the error and allow it to recompile automatically on save.

![screen shot 2014-02-18 at 6 24 45 pm](https://f.cloud.github.com/assets/2625486/2201758/db2e8932-98f3-11e3-9db0-c5df15d7b7b7.png)

I personally think this should be the default behavior, but I made it an option because some people may expect the current behavior of stopping the process.
