### PR TITLE
fixes issue #33

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,11 +17,12 @@ module.exports = function (options) {
 
     stylus.render(file.contents.toString('utf8'), opts)
     .catch(function(err){
-      if(err) new Error(err);
+      if(err) cb(new Error(err));
     })
     .done(function(css){
       file.path = rext(file.path, '.css');
-      file.contents = new Buffer(css);
+      //create a 0 length buffer if css is undefined due to some error
+      file.contents = new Buffer(css || 0);
       cb(null, file);
     });
 


### PR DESCRIPTION
two small changes:

line 20:  pass on the error so it can be handled explicitly in the gulpfile

```
-      if(err) new Error(err);
+      if(err) cb(new Error(err));
```

line 24: if render was not successfull, the _css_ variavle is undefined and causes the Buffer allocation to fail.  So if it failed, just allocate a 0 sized buffer instead.

```
-      file.contents = new Buffer(css);
 +      //create a 0 length buffer if css is undefined due to some error
 +      file.contents = new Buffer(css || 0);
```
