### PR TITLE
Fixes correct error reporting

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,13 +16,13 @@ module.exports = function (options) {
       opts.filename = file.path;
 
     stylus.render(file.contents.toString('utf8'), opts)
-    .catch(function(err){
-      if(err) new Error(err);
-    })
-    .done(function(css){
+    .then(function(css){
       file.path = rext(file.path, '.css');
       file.contents = new Buffer(css);
       cb(null, file);
+    })
+    .catch(function(err){
+      cb(err);
     });
 
   }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   "devDependencies": {
     "gulp-util": "^2.2.14",
     "mocha": "*",
-    "should": "*"
+    "should": "*",
+    "gulp": "^3.6.1"
   },
   "engines": {
     "node": ">= 0.9.0"

--- a/test/errors.js
+++ b/test/errors.js
@@ -1,0 +1,22 @@
+/*eslint-env node, mocha */
+/*eslint quotes:[2, "single"], strict: 0*/
+var path = require('path');
+
+var should = require('should');
+var gulp = require('gulp');
+var stylus = require('../');
+
+describe('when throw error', function(){
+    it('should be processed as natural', function(done){
+        var filepath = path.resolve(__dirname, './fixtures/incorrect.styl');
+        gulp
+            .src(filepath)
+            .pipe(stylus())
+            .on('error', function(err){
+                err.should.be.instanceof(Error);
+                err.name.should.be.equal('ParseError');
+                err.message.should.startWith(filepath);
+                done();
+            });
+    });
+});

--- a/test/fixtures/incorrect.styl
+++ b/test/fixtures/incorrect.styl
@@ -1,0 +1,3 @@
+.something
+    - if --
+        any body


### PR DESCRIPTION
I saw #35, but I dare to suggest my fix. It seems better for reporting to return the same error Stylus produced, not to wrap it in another Error constructor.
