### PR TITLE
Replace map-stream to through2

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var map = require('map-stream');
+var map = require('through2').obj;
 var stylus = require('accord').load('stylus');
 var rext = require('replace-ext');
 var path = require('path');
@@ -6,7 +6,7 @@ var path = require('path');
 module.exports = function (options) {
   var opts = options ? options : {};
 
-  function stylusstream (file, cb) {
+  function stylusstream (file, enc, cb) {
 
     if (file.isNull()) return cb(null, file); // pass along
     if (file.isStream()) return cb(new Error("gulp-stylus: Streaming not supported"));

--- a/package.json
+++ b/package.json
@@ -10,11 +10,11 @@
   "author": "Steve Lacy <me@slacy.me> (http://slacy.me) | Fractal (http://wearefractal.com)",
   "main": "./index.js",
   "dependencies": {
-    "map-stream": "^0.1.0",
     "nib": "^1.0.2",
     "accord": "0.0.9",
     "replace-ext": "0.0.1",
-    "stylus": "^0.43.1"
+    "stylus": "^0.43.1",
+    "through2": "^0.4.1"
   },
   "devDependencies": {
     "gulp-util": "^2.2.14",


### PR DESCRIPTION
I suggest to use `through2` to process streams instead of `map-stream`. It seems like standard for gulp plugins, more supported and works great with `gulp-plumber`.
