### PR TITLE
Add gulp-util to main deps, correct error

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,9 @@
+var path = require('path');
+
 var map = require('map-stream');
 var stylus = require('accord').load('stylus');
-var rext = require('replace-ext');
-var path = require('path');
+var rext = require('gulp-util').replaceExtension;
+var PluginError = require('gulp-util').PluginError;
 
 module.exports = function (options) {
   var opts = options ? options : {};
@@ -9,7 +11,7 @@ module.exports = function (options) {
   function stylusstream (file, cb) {
 
     if (file.isNull()) return cb(null, file); // pass along
-    if (file.isStream()) return cb(new Error("gulp-stylus: Streaming not supported"));
+    if (file.isStream()) return cb(new PluginError('gulp-stylus', 'Streaming not supported'));
     if (path.extname(file.path) === '.css') return cb(null, file);
 
     if (!opts.filename)

--- a/package.json
+++ b/package.json
@@ -13,11 +13,10 @@
     "map-stream": "^0.1.0",
     "nib": "^1.0.2",
     "accord": "0.0.9",
-    "replace-ext": "0.0.1",
-    "stylus": "^0.43.1"
+    "stylus": "^0.43.1",
+    "gulp-util": "^2.2.14"
   },
   "devDependencies": {
-    "gulp-util": "^2.2.14",
     "mocha": "*",
     "should": "*"
   },


### PR DESCRIPTION
We should use `gulp-util` for correct plugin errors and to replace `replace-ext` package.
