### PR TITLE
Add define to options

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,16 @@ The name of the file if required to be set
 
 ```
 
+### define
+Allows you to define global variables in gulp that will be accessible in your Stylus files.
 
+	default: {}
+
+```js
+
+.pipe(stylus({ define: { color: 'blue' } }))
+
+```  
 
 ####You can view more examples in the [example folder.](https://github.com/stevelacy/gulp-stylus/tree/master/examples)
 

--- a/examples/css/define.styl
+++ b/examples/css/define.styl
@@ -1,0 +1,2 @@
+body
+  color: color

--- a/examples/css/define/define.css
+++ b/examples/css/define/define.css
@@ -1,0 +1,3 @@
+body {
+  color: 'red';
+}

--- a/examples/gulpfile.js
+++ b/examples/gulpfile.js
@@ -3,7 +3,6 @@ var gulp = require('gulp');
 var nib = require('nib');
 var stylus = require('../');
 
-
 // Get one .styl file and render
 gulp.task('one', function () {
 	gulp.src('./css/one.styl')
@@ -40,6 +39,12 @@ gulp.task('errors', function () {
     .pipe(gulp.dest('./css/errors'));
 });
 
+// Define a variable
+gulp.task('define', function () {
+  gulp.src('./css/define.styl')
+    .pipe(stylus({define: { color: 'red' }}))
+    .pipe(gulp.dest('./css/define'));
+});
 
 // Default gulp task to run
 gulp.task('default', ['nib', 'one']);

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ var path = require('path');
 module.exports = function (options) {
   var opts = options ? options : {};
   var paths = opts.paths ? opts.paths : [];
-  
+
   return through.obj(function (file, enc, cb) {
 
     if (file.isStream()) return cb(new gutil.PluginError("gulp-stylus: Streaming not supported"));
@@ -19,6 +19,7 @@ module.exports = function (options) {
       this.push(file);
       return cb();
     }
+    if (!opts.define) opts.define = {};
     if (!opts.filename) opts.filename = file.path;
     if (!opts.paths) opts.paths = paths.concat([path.dirname(file.path)]);
 


### PR DESCRIPTION
I've run into the problem of having to pass a variable to my stylus files via my gulp tasks every now and then and think it's probably something other people want to do. To be honest, I don't know why we can't get this plugin up to par with the grunt equivalent (https://github.com/gruntjs/grunt-contrib-stylus). Feature parity would be ideal. 

Unfortunately, I don't have time to add all the other options but it should be fairly simple.
