### PR TITLE
callback after emit error

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ var path = require('path');
 module.exports = function (options) {
   var opts = options ? options : {};
   var paths = opts.paths ? opts.paths : [];
-  
+
   return through.obj(function (file, enc, cb) {
 
     if (file.isStream()) return cb(new gutil.PluginError("gulp-stylus: Streaming not supported"));
@@ -28,6 +28,7 @@ module.exports = function (options) {
       if(err){
         if(opts.errors) gutil.log('gulp-stylus', gutil.colors.cyan(err));
         that.emit('error', new gutil.PluginError('gulp-stylus', err));
+        cb();
       }
     })
     .then(function(css){


### PR DESCRIPTION
if use gulp-plumber it will stop watching because halt from emit error.

the condition code is like below

```
var plumber = require('gulp-plumber');
gulp.task('build', function(){
  gulp.src('*.styl')
    .pipe(plumber())
    .pipe(gulp-stylus())
    .pipe(gulp-dest('.'))
});

gulp.task('watch', function(){
  gulp.watch('*.style', 'build')
});
```
