### PR TITLE
fixed: will only try and parse css if it exists

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ var path = require('path');
 module.exports = function (options) {
   var opts = options ? options : {};
   var paths = opts.paths ? opts.paths : [];
-  
+
   return through.obj(function (file, enc, cb) {
 
     if (file.isStream()) return cb(new gutil.PluginError("gulp-stylus: Streaming not supported"));
@@ -31,9 +31,11 @@ module.exports = function (options) {
       }
     })
     .then(function(css){
-      file.path = rext(file.path, '.css');
-      file.contents = new Buffer(css);
-      that.push(file);
+      if (css) {
+        file.path = rext(file.path, '.css');
+        file.contents = new Buffer(css);
+        that.push(file);
+      }
       cb();
     });
   });


### PR DESCRIPTION
Fixes the Type Error when there is no css to compile. Allow you to use a simple gulp task to support live reloading and not have to restart the process.

``` javascript
gulp.task('stylus', function () {
  return gulp.src('src/style.styl')
    .pipe(stylus())
    .on('error', function () {this.emit('end')})
    .pipe(gulp.dest('.'));
});
```

Closes #51
Fixes #46, #50
