### PR TITLE
Only emit PluginError if errors aren't logged

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ module.exports = function (options) {
     .catch(function(err){
       if(err){
         if(opts.errors) gutil.log('gulp-stylus', gutil.colors.cyan(err));
-        that.emit('error', new gutil.PluginError('gulp-stylus', err));
+        else that.emit('error', new gutil.PluginError('gulp-stylus', err));
       }
     })
     .then(function(css){


### PR DESCRIPTION
When passing `{ errors: true }` to gulp-stylus, the error gets logged to the console by gulp-stylus and then gulp itself logs the PluginError again with a (very long) stacktrace saying it is "potentially unhandled".

This pull request changes gulp-stylus so that the error isn't emitted to gulp if it has been logged to the console. I'm not sure if there are any other implications to not emitting the error but it seems to do the job for me.

(I'm using the latest version of gulp, 3.7)
