### PR TITLE
Plugin doesn't handle .styl with @import or @require

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ module.exports = function (options) {
       this.push(file);
       return cb();
     }
-    if (!opts.filename) opts.filename = file.path;
+    opts.filename = file.path;
     if (!opts.paths) opts.paths = paths.concat([path.dirname(file.path)]);
 
     that = this;


### PR DESCRIPTION
If file  has @import or @require directives the plugin doesn't  handle this source properly. It was fixed  with updating options filename on every iteration.
