### PR TITLE
Enable gulp-sourcemaps to work automatically

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ lib-cov
 pids
 logs
 results
+.idea
 
 npm-debug.log
 node_modules

--- a/README.md
+++ b/README.md
@@ -91,19 +91,11 @@ gulp.task('sourcemaps-inline', function () {
     .pipe(gulp.dest('./css/build'));
 });
 
-// External sourcemaps
+// Using gulp-sourcemaps
 gulp.task('sourcemaps-external', function () {
   gulp.src('./css/sourcemaps-external.styl')
-    .pipe(stylus({
-      sourcemap: {
-        inline: true,
-        sourceRoot: '.',
-        basePath: 'css/build'
-      }
-    }))
-    .pipe(sourcemaps.init({
-      loadMaps: true
-    }))
+    .pipe(sourcemaps.init())
+    .pipe(stylus()) // automatically enabled
     // Here you can you can use plugins that supports gulp-sourcemaps.
     // See gulp-sourcemaps readme for a list of such plugins.
     // For example, using pleeease:
@@ -111,11 +103,8 @@ gulp.task('sourcemaps-external', function () {
     //   minifier: false,
     //   sourcemaps: true
     // }))
-    .pipe(sourcemaps.write('.', {
-      includeContent: false,
-      sourceRoot: '.'
-    }))
-    .pipe(gulp.dest('./css/build'));
+    .pipe(sourcemaps.write('.'))
+    .pipe(gulp.dest('./css/build')); // outputs both sourcemaps-external.css & sourcemaps-external.css.map
 });
 
 // Default gulp task to run
@@ -126,7 +115,7 @@ gulp.task('default', ['one', 'compress', 'nib', 'linenos', 'sourcemaps-inline', 
 #####You can view more examples in the [example folder.](https://github.com/stevelacy/gulp-stylus/tree/master/examples)
 
 ## Options
-#### All stylus options are passed to [accord/stylus](https://github.com/jenius/accord/blob/master/docs/stylus.md)
+#### All stylus options are handled exactly as [accord/stylus](https://github.com/jenius/accord/blob/master/docs/stylus.md)
 
 
 

--- a/index.js
+++ b/index.js
@@ -1,46 +1,102 @@
 'use strict';
 
 var through = require('through2');
-var stylus  = require('accord').load('stylus');
-var gutil   = require('gulp-util');
-var rext    = require('replace-ext');
-var path    = require('path');
-var _       = require('lodash');
+var stylus = require('stylus');
+var gutil = require('gulp-util');
+var rext = require('replace-ext');
+var path = require('path');
+var _ = require('lodash');
+var applySourceMap = require('vinyl-sourcemaps-apply');
 
 var PLUGIN_NAME = 'gulp-stylus';
 
-module.exports = function (options) {
-  var opts = _.cloneDeep(options) || {};
+module.exports = function(options) {
+	var opts = _.cloneDeep(options) || {};
 
-  _.defaults(opts, {
-    paths: []
-  });
+	_.defaults(opts, {
+		paths: []
+	});
 
-  return through.obj(function (file, enc, cb) {
+	return through.obj(function(file, enc, cb) {
 
-    if (file.isStream()) {
-      return cb(new gutil.PluginError(PLUGIN_NAME, 'Streaming not supported'));
-    }
-    if (file.isNull()){
-      return cb(null, file);
-    }
-    if (path.extname(file.path) === '.css'){
-      return cb(null, file);
-    }
-    opts.filename = file.path;
-    opts.paths.push(path.dirname(file.path));
+		if(file.isStream()) {
+			return cb(new gutil.PluginError(PLUGIN_NAME, 'Streaming not supported'));
+		}
+		if(file.isNull()) {
+			return cb(null, file);
+		}
+		if(path.extname(file.path) === '.css') {
+			return cb(null, file);
+		}
 
-    stylus.render(file.contents.toString('utf8'), opts)
-    .catch(function(err){
-      return cb(new gutil.PluginError(PLUGIN_NAME, err));
-    })
-    .then(function(css){
-      if (css !== undefined){
-        file.path = rext(file.path, '.css');
-        file.contents = new Buffer(css);
-        return cb(null, file);
-      }
-    });
-  });
+		if(file.sourceMap) {
+			opts.sourcemap = { comment: false };
+		}
+
+		opts.filename = file.path;
+		opts.paths.push(path.dirname(file.path));
+
+		var styler = stylus(file.contents.toString('utf8'));
+		configureStylus(styler, opts);
+		var css;
+		try {
+			css = styler.render();
+		} catch(err) {
+			return cb(new gutil.PluginError(PLUGIN_NAME, err));
+		}
+		if(css !== undefined) {
+			file.path = rext(file.path, '.css');
+			file.contents = new Buffer(css);
+			if(file.sourceMap) {
+				applySourceMap(file, styler.sourcemap);
+			}
+			return cb(null, file);
+		}
+	});
 
 };
+
+function configureStylus(styler, opts) {
+	var handlers = {
+		'define': function(v) {
+			_.forIn(v, function(val, prop) { styler.define(prop, val) });
+		},
+		'include': function(v) {
+			v = _.isArray(v) ? v : [v];
+			_.forEach(v, function(val) { styler.include(val) });
+		},
+		'import': function(v) {
+			v = _.isArray(v) ? v : [v];
+			_.forEach(v, function(val) { styler['import'](val) });
+		},
+		'use': function(v) {
+			v = _.isArray(v) ? v : [v];
+			_.forEach(v, function(val) { styler.use(val) });
+		},
+		'url': function(v) {
+			var name = v,
+				fn;
+			if(typeof v === 'string') {
+				fn = stylus.url();
+			} else {
+				name = v.name;
+				fn = stylus.url({
+					                limit: v.limit != null ? v.limit : 30000,
+					                paths: v.paths || []
+				                });
+			}
+			styler.define(name, fn);
+		}
+	};
+	opts = _.clone(opts);
+
+	_.forIn(opts, function(v, k) {
+		if(!handlers[k]) {
+			styler.set(k, v);
+			delete opts[k];
+		}
+	});
+	_.forIn(opts, function(v, k) {
+		handlers[k](v);
+	});
+}

--- a/package.json
+++ b/package.json
@@ -10,14 +10,15 @@
   "author": "Steve Lacy <me@slacy.me> (http://slacy.me) | Fractal (http://wearefractal.com)",
   "main": "./index.js",
   "dependencies": {
-    "accord": "^0.12.0",
     "gulp-util": "^3.0.1",
+    "lodash": "~2.4.1",
     "replace-ext": "0.0.1",
     "stylus": "*",
     "through2": "^0.6.1",
-    "lodash": "~2.4.1"
+    "vinyl-sourcemaps-apply": "^0.1.4"
   },
   "devDependencies": {
+    "gulp-sourcemaps": "^1.2.4",
     "mocha": "*",
     "should": "*"
   },

--- a/test/main.js
+++ b/test/main.js
@@ -4,21 +4,22 @@ var should = require('should');
 var gutil = require('gulp-util');
 var stylus = require('../');
 var fs = require('fs');
+var gulpSourcemaps = require('gulp-sourcemaps');
 
 require('mocha');
 
-describe('gulp-stylus', function(){
-	it('should render stylus .styl to CSS .css', function(done){
+describe('gulp-stylus', function() {
+	it('should render stylus .styl to CSS .css', function(done) {
 		var stream = stylus();
 
 		var fakeFile = new gutil.File({
-			base: 'test/fixtures',
-			cwd: 'test/',
-			path: 'test/fixtures/normal.styl',
-			contents: fs.readFileSync('test/fixtures/normal.styl')
-		});
+			                              base: 'test/fixtures',
+			                              cwd: 'test/',
+			                              path: 'test/fixtures/normal.styl',
+			                              contents: fs.readFileSync('test/fixtures/normal.styl')
+		                              });
 
-		stream.once('data', function(newFile){
+		stream.once('data', function(newFile) {
 			should.exist(newFile);
 			should.exist(newFile.contents);
 			String(newFile.contents).should.equal(fs.readFileSync('test/expected/normal.css', 'utf8'));
@@ -29,14 +30,14 @@ describe('gulp-stylus', function(){
 
 	});
 
-	it ('should compress when called', function(done){
+	it('should compress when called', function(done) {
 		var stream = stylus({compress: true});
 		var fakeFile = new gutil.File({
-			base: 'test/fixtures',
-			cwd: 'test/',
-			path: 'test/fixtures/normal.styl',
-			contents: fs.readFileSync('test/fixtures/normal.styl')
-		});
+			                              base: 'test/fixtures',
+			                              cwd: 'test/',
+			                              path: 'test/fixtures/normal.styl',
+			                              contents: fs.readFileSync('test/fixtures/normal.styl')
+		                              });
 
 		stream.on('data', function(newFile) {
 			should.exist(newFile);
@@ -50,14 +51,14 @@ describe('gulp-stylus', function(){
 		stream.end();
 	});
 
-	it ('should import other .styl files', function(done){
+	it('should import other .styl files', function(done) {
 		var stream = stylus({import: __dirname + '/fixtures/one.styl'});
 		var fakeFile = new gutil.File({
-			base: 'test/fixtures',
-			cwd: 'test/',
-			path: 'test/fixtures/normal.styl',
-			contents: fs.readFileSync('test/fixtures/normal.styl')
-		});
+			                              base: 'test/fixtures',
+			                              cwd: 'test/',
+			                              path: 'test/fixtures/normal.styl',
+			                              contents: fs.readFileSync('test/fixtures/normal.styl')
+		                              });
 
 		stream.on('data', function(newFile) {
 			should.exist(newFile);
@@ -71,14 +72,14 @@ describe('gulp-stylus', function(){
 		stream.end();
 	});
 
-	it ('should define variables in .styl files', function(done){
+	it('should define variables in .styl files', function(done) {
 		var stream = stylus({define: {'white': '#fff'}});
 		var fakeFile = new gutil.File({
-			base: 'test/fixtures',
-			cwd: 'test/',
-			path: 'test/fixtures/define.styl',
-			contents: fs.readFileSync('test/fixtures/define.styl')
-		});
+			                              base: 'test/fixtures',
+			                              cwd: 'test/',
+			                              path: 'test/fixtures/define.styl',
+			                              contents: fs.readFileSync('test/fixtures/define.styl')
+		                              });
 
 		stream.on('data', function(newFile) {
 			should.exist(newFile);
@@ -92,17 +93,17 @@ describe('gulp-stylus', function(){
 		stream.end();
 	});
 
-	it('should skip css files', function(done){
+	it('should skip css files', function(done) {
 		var stream = stylus();
 
 		var fakeFile = new gutil.File({
-			base: 'test/fixtures',
-			cwd: 'test/',
-			path: 'test/fixtures/ie8.css',
-			contents: fs.readFileSync('test/fixtures/ie8.css')
-		});
+			                              base: 'test/fixtures',
+			                              cwd: 'test/',
+			                              path: 'test/fixtures/ie8.css',
+			                              contents: fs.readFileSync('test/fixtures/ie8.css')
+		                              });
 
-		stream.once('data', function(newFile){
+		stream.once('data', function(newFile) {
 			should.exist(newFile);
 			should.exist(newFile.contents);
 			String(newFile.contents).should.equal(fs.readFileSync('test/fixtures/ie8.css', 'utf8'));
@@ -114,36 +115,36 @@ describe('gulp-stylus', function(){
 	});
 
 
-	it('should throw on parse error', function(done){
+	it('should throw on parse error', function(done) {
 		var stream = stylus();
 
 		var file = 'test/fixtures/error.styl';
 
 		var fakeFile = new gutil.File({
-			base: 'test/fixtures',
-			cwd: 'test/',
-			path: file,
-			contents: fs.readFileSync(file)
-		});
+			                              base: 'test/fixtures',
+			                              cwd: 'test/',
+			                              path: file,
+			                              contents: fs.readFileSync(file)
+		                              });
 
 		stream.on('error', function(err) {
 			should.exist(err);
 			err.name.toString().should.match(/ParseError/);
 			done();
 		});
-    stream.write(fakeFile);
-    stream.end();
+		stream.write(fakeFile);
+		stream.end();
 
-  });
+	});
 
-	it ('should import nested and reverse recursive files', function(done){
+	it('should import nested and reverse recursive files', function(done) {
 		var stream = stylus();
 		var fakeFile = new gutil.File({
-			base: 'test/fixtures',
-			cwd: 'test/',
-			path: 'test/fixtures/import.styl',
-			contents: fs.readFileSync('test/fixtures/import.styl')
-		});
+			                              base: 'test/fixtures',
+			                              cwd: 'test/',
+			                              path: 'test/fixtures/import.styl',
+			                              contents: fs.readFileSync('test/fixtures/import.styl')
+		                              });
 
 		stream.on('data', function(newFile) {
 			should.exist(newFile);
@@ -155,19 +156,43 @@ describe('gulp-stylus', function(){
 		stream.end();
 	});
 
-	it ('should create inline sourcemaps', function(done){
+	it('should create inline sourcemaps', function(done) {
 		var stream = stylus({sourcemap: {inline: true}});
 		var fakeFile = new gutil.File({
-			base: 'test/fixtures',
-			cwd: 'test/',
-			path: 'test/fixtures/normal.styl',
-			contents: fs.readFileSync('test/fixtures/normal.styl')
-		});
+			                              base: 'test/fixtures',
+			                              cwd: 'test/',
+			                              path: 'test/fixtures/normal.styl',
+			                              contents: fs.readFileSync('test/fixtures/normal.styl')
+		                              });
 
 		stream.on('data', function(newFile) {
 			should.exist(newFile);
 			should.exist(newFile.contents);
 			String(newFile.contents).should.equal(fs.readFileSync('test/expected/sourcemap.css', 'utf8'));
+			done();
+		});
+		stream.write(fakeFile);
+		stream.end();
+	});
+
+	it('should work with gulp-sourcemaps', function(done) {
+		var stream = gulpSourcemaps.init();
+		var fakeFile = new gutil.File({
+			                              base: 'test/fixtures',
+			                              cwd: 'test/',
+			                              path: 'test/fixtures/normal.styl',
+			                              contents: fs.readFileSync('test/fixtures/normal.styl')
+		                              });
+
+		stream.pipe(stylus()).on('data', function(newFile) {
+			should.exist(newFile);
+			should.exist(newFile.contents);
+			String(newFile.contents).should.equal(fs.readFileSync('test/expected/normal.css', 'utf8'));
+			should.exist(newFile.sourceMap);
+			console.log(newFile.sourceMap);
+			newFile.sourceMap.sources.length.should.equal(1);
+			newFile.sourceMap.sources[0].should.equal('test/fixtures/normal.styl');
+			newFile.sourceMap.mappings.should.equal('AAGA;EACE,OAAM,KAAN;EACA,QAAQ,IAAR;;AACF;EACE,YAAW,KAAX;;AACA;EACE,YAAW,KAAX');
 			done();
 		});
 		stream.write(fakeFile);


### PR DESCRIPTION
This might not be a road you want to go down, but I rewrote the plugin to use Stylus directly, completely removing Accord from the equation.  I ported over Accord's option processing (although much simplified from the generated CofeeScript), so all the original functionality exists without any changes.

Existing code should not be affected in any way.

The benefit is that simply activating sourcemaps as directed by `gulp-sourcemaps` automatically enables sourcemap processing.  This change _also_ allows developers to apply changes prior to `gulp-stylus`, so you can do things like concat files before stylus processes them, and get the original sourcemap.

To make this change, I:
- Rewrote the existing code
- Removed the Accord library
- Added the vinyl-sourcemaps-apply library
- Added a test for the new functionality
- Updated the README to reflect the recommended `gulp-sourcemaps` technique.
- I also did my best to match your existing code style, although I might have changed some things accidentally because there was no editorconfig, and I think some files had tabs, and other had spaces.

If this is something you would like to use, let me know if you need me to make any changes.
