### PR TITLE
Do not add `paths` to Stylus options, which breaks nib and `@require`

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,10 +12,6 @@ var PLUGIN_NAME = 'gulp-stylus';
 module.exports = function (options) {
   var opts = _.cloneDeep(options) || {};
 
-  _.defaults(opts, {
-    paths: []
-  });
-
   return through.obj(function (file, enc, cb) {
 
     if (file.isStream()) {
@@ -28,7 +24,6 @@ module.exports = function (options) {
       return cb(null, file);
     }
     opts.filename = file.path;
-    opts.paths.push(path.dirname(file.path));
 
     stylus.render(file.contents.toString('utf8'), opts)
     .catch(function(err){


### PR DESCRIPTION
In the latest version of Stylus, overriding the `paths` option breaks nib and uses of `@require` which don't start at the node process CWD. This is bad. As it has been unnecessary to set `paths` to the file's dirname for some time, I have removed this entirely.
