### PR TITLE
Fix paths in sourcemaps

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,6 +38,7 @@ module.exports = function (options) {
         file.path = rext(file.path, '.css');
         file.contents = new Buffer(res.result);
         if (res.sourcemap) {
+          makePathsRelative(file, res.sourcemap);
           applySourceMap(file, res.sourcemap);
         }
         return cb(null, file);
@@ -46,3 +47,9 @@ module.exports = function (options) {
   });
 
 };
+
+function makePathsRelative(file, sourcemap) {
+  for (var i = 0; i < sourcemap.sources.length; i++) {
+    sourcemap.sources[i] = path.relative(file.base, sourcemap.sources[i]);
+  }
+}


### PR DESCRIPTION
Now sourcemap paths are relative to cwd (or gulpfile.js) and for external sourcemaps and `includeContent: false` it's useless.
Here is the same fix as applied in [gulp-less](https://github.com/plus3network/gulp-less/blob/master/index.js#L55-L57).