### PR TITLE
Improve error handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,19 +30,19 @@ module.exports = function (options) {
     opts.filename = file.path;
 
     stylus.render(file.contents.toString('utf8'), opts)
-    .catch(function(err) {
-      return cb(new gutil.PluginError(PLUGIN_NAME, err));
-    })
-    .then(function(res) {
-      if (res.result !== undefined) {
-        file.path = rext(file.path, '.css');
-        file.contents = new Buffer(res.result);
-        if (res.sourcemap) {
-          applySourceMap(file, res.sourcemap);
+      .then(function(res) {
+        if (res.result !== undefined) {
+          file.path = rext(file.path, '.css');
+          file.contents = new Buffer(res.result);
+          if (res.sourcemap) {
+            applySourceMap(file, res.sourcemap);
+          }
+          return cb(null, file);
         }
-        return cb(null, file);
-      }
-    });
+      })
+      .catch(function(err) {
+        return cb(new gutil.PluginError(PLUGIN_NAME, err));
+      });
   });
 
 };


### PR DESCRIPTION
When some fatal error occurs in stylus the result (`res`) is undefined and condition `res.result !== undefined` throws an error:

```
Potentially unhandled rejection [2] TypeError: Cannot read property 'result' of undefined
```

This PR places catcher function into `then` second argument so it doesn't happen because only one of them is executed.