### PR TITLE
Fix stylus version to the most recent major version

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "gulp-util": "^3.0.3",
     "lodash": "^3.2.0",
     "replace-ext": "0.0.1",
-    "stylus": "*",
+    "stylus": "~0.51.1",
     "through2": "^0.6.3",
     "vinyl-sourcemaps-apply": "^0.1.4"
   },


### PR DESCRIPTION
It would probably be a good idea to fix the version of Stylus. v1.0 will be published somewhere in the future with some non-backwards compatible changes and many builds are going to fail because of this. 