### PR TITLE
update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,10 +30,7 @@
   "scripts": {
     "test": "mocha --reporter spec"
   },
-  "licenses": {
-    "type": "MIT",
-    "url": "https://github.com/stevelacy/gulp-stylus/raw/master/LICENSE"
-  },
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/stevelacy/gulp-stylus/issues"
   },


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/