### PR TITLE
fix bug with sourcemaps

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,8 +36,8 @@ module.exports = function (options) {
           file.contents = new Buffer(res.result);
           if (res.sourcemap) {
             makePathsRelative(file, res.sourcemap);
+            res.sourcemap.file = file.relative;
             applySourceMap(file, res.sourcemap);
-            file.sourceMap.file = file.relative;
           }
           return cb(null, file);
         }


### PR DESCRIPTION
Fix the following bug:

```
[10:16:54] Error in plugin 'gulp-stylus'
Message:
    Source map to be applied is missing the "file" property
Details:
    domainEmitter: [object Object]
    domain: [object Object]
    domainThrown: false
```