### PR TITLE
exposed native stylus module

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,12 @@ gulp.task('default', ['one', 'compress', 'linenos', 'sourcemaps-inline', 'source
 
 ##### You can view more examples in the [example folder.](https://github.com/stevelacy/gulp-stylus/tree/master/examples)
 
+## Extras
+You can access the original `stylus` module that `gulp-stylus` uses.
+```
+var originalStylus = require('gulp-stylus').stylus;
+```
+
 ## Options
 #### All stylus options are passed to [accord/stylus](https://github.com/jenius/accord/blob/master/docs/stylus.md)
 

--- a/index.js
+++ b/index.js
@@ -50,6 +50,8 @@ module.exports = function (options) {
 
 };
 
+module.exports.stylus = require('stylus');
+
 function makePathsRelative(file, sourcemap) {
   for (var i = 0; i < sourcemap.sources.length; i++) {
     sourcemap.sources[i] = path.relative(file.base, sourcemap.sources[i]);


### PR DESCRIPTION
It's frequent to need the original `stylus` module in gulpfiles, but annoying to install both `stylus` and `gulp-stylus`.
Therefore, I've exposed the `stylus` module within `gulp-stylus`.