### PR TITLE
Properly emit errors so they can be listened for

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,12 @@ module.exports = function (options) {
     opts.filename = file.path;
 
     stylus.render(file.contents.toString('utf8'), opts)
-      .then(function(res) {
+      .catch(function(err) {
+        delete err.input;
+        return cb(new gutil.PluginError(PLUGIN_NAME, err));
+      })
+      .done(function(res) {
+        if (res == null) return;
         if (res.result !== undefined) {
           file.path = rext(file.path, '.css');
           if (res.sourcemap) {
@@ -41,10 +46,6 @@ module.exports = function (options) {
           file.contents = new Buffer(res.result);
           return cb(null, file);
         }
-      })
-      .catch(function(err) {
-        delete err.input;
-        return cb(new gutil.PluginError(PLUGIN_NAME, err));
       });
   });
 


### PR DESCRIPTION
Hi!

With the current way `gulp-stylus` handles the promise returned by `accord`, errors won't be emitted on the stream, preventing simple things like:

```
var stylus = require("gulp-stylus");
gulp.task("stylus", function() {
  return gulp.src("./src/styles/*.styl")
    .pipe(stylus())
    .on("error", function(err) { /* Log the error or do something else with it */ });
    .pipe(gulp.dest("../public/styles"));
});
```

Instead, errors are always logged with `Potentially unhandled rejection [2]` prepended and there's no straightforward way to handle them programmatically.

This pull request matches the style recommended in the [accord stylus documentation](https://github.com/jenius/accord/blob/master/docs/stylus.md) by using `.catch` first (important!) and then using `.done` rather than `.then` (required for the error to be emitted).

Note that this means errors will be thrown by default, unless an `.on("error", ...)` handler is provided. If this isn't desirable, maybe there's a better way that doesn't throw by default but still allows listening for the "error" event in the stream, but I couldn't find one.