### PR TITLE
remove should from dep and update its devdep

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "gulp-util": "^3.0.6",
     "lodash.assign": "^3.2.0",
     "replace-ext": "0.0.1",
-    "should": "^8.0.2",
     "stylus": "^0.54.0",
     "through2": "^2.0.0",
     "vinyl-sourcemaps-apply": "^0.2.0"
@@ -22,7 +21,7 @@
   "devDependencies": {
     "gulp-sourcemaps": "^1.5.2",
     "mocha": "^2.3.2",
-    "should": "^7.1.0"
+    "should": "^8.0.2"
   },
   "engines": {
     "node": ">= 0.9.0"


### PR DESCRIPTION
`should` was listed in both the dependencies and devDependencies list even though it was only used in testing.