### PR TITLE
Locks stylus to 0.54.0 for now because 0.54.1 breaks

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "gulp-util": "^3.0.6",
     "lodash.assign": "^3.2.0",
     "replace-ext": "0.0.1",
-    "stylus": "^0.54.0",
+    "stylus": "0.54.0",
     "through2": "^2.0.0",
     "vinyl-sourcemaps-apply": "^0.2.0"
   },


### PR DESCRIPTION
0.54.1 is breaking require('gulp-stylus') which is no fun.  Would like to lock this for now until the stylus team figures out what's up.