### PR TITLE
add support for using gulp-data to define variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ $ npm install --save-dev gulp-stylus
 
 // include the required packages.
 var gulp = require('gulp');
+var data = require('gulp-data');
 var stylus = require('gulp-stylus');
 
 
@@ -103,6 +104,18 @@ var data = {red: '#ff0000'};
 gulp.task('pass-object', function () {
   gulp.src('./sty/main.styl')
     .pipe(stylus({ rawDefine: { data: data }}))
+    .pipe(gulp.dest('./css/build'));
+});
+
+// Use with gulp-data
+gulp.task('gulp-data', function() {
+  gulp.src('./components/**/*.styl')
+    .pipe(data(function(){
+      return {
+        componentPath: '/' + (file.path.replace(file.base, '').replace(/\/[^\/]*$/, ''));
+      };
+    }))
+    .pipe(stylus())
     .pipe(gulp.dest('./css/build'));
 });
 

--- a/index.js
+++ b/index.js
@@ -29,6 +29,9 @@ module.exports = function (options) {
     if (file.sourceMap || opts.sourcemap) {
       opts.sourcemap = assign({basePath: file.base}, opts.sourcemap);
     }
+    if (file.data) {
+      opts.define = file.data;
+    }
     opts.filename = file.path;
 
     stylus.render(file.contents.toString(enc || 'utf-8'), opts)

--- a/test/main.js
+++ b/test/main.js
@@ -97,6 +97,29 @@ describe('gulp-stylus', function() {
     stream.end();
   });
 
+  it ('should support defining variables in .styl files using gulp-data (data object attached to file)', function(done) {
+    var stream = stylus();
+    var fakeFile = new gutil.File({
+      base: 'test/fixtures',
+      cwd: 'test/',
+      path: 'test/fixtures/define.styl',
+      contents: fs.readFileSync('test/fixtures/define.styl')
+    });
+
+    fakeFile.data = {'white': '#fff'};
+
+    stream.on('data', function(newFile) {
+      should.exist(newFile);
+      should.exist(newFile.contents);
+
+      String(newFile.contents).should.equal(fs.readFileSync('test/expected/define.css', 'utf8'));
+      done();
+    });
+
+    stream.write(fakeFile);
+    stream.end();
+  });
+
   it('should skip css files', function(done) {
     var stream = stylus();
 
@@ -244,7 +267,7 @@ describe('gulp-stylus', function() {
   stream.end();
 
   });
-  
+
   it('should export Stylus', function(done) {
     should.exist(stylus.stylus);
     should(stylus.stylus).equal(originalStylus);

--- a/test/main.js
+++ b/test/main.js
@@ -112,6 +112,10 @@ describe('gulp-stylus', function() {
       should.exist(newFile);
       should.exist(newFile.contents);
 
+      should.exist(newFile.data);
+      should.exist(newFile.data.white);
+      should(newFile.data.white).equal('#fff');
+
       String(newFile.contents).should.equal(fs.readFileSync('test/expected/define.css', 'utf8'));
       done();
     });


### PR DESCRIPTION
I like to keep images in their respective component folders. Maintenance can be a pain if you decide to rename a component or restructure your project. Using a variable in your stylus files which holds the path to your component makes things much easier.

the jade gulp plugin already supports this.