### PR TITLE
Remove sourceMappingURL comment even when Stylus compress is true.

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ module.exports = function (options) {
         if (res.result !== undefined) {
           file.path = rext(file.path, '.css');
           if (res.sourcemap) {
-            res.result = res.result.replace(/^\s*\/\*[@#][\s\t]+sourceMappingURL=.*$/mg, '');
+            res.result = res.result.replace(/\/\*[@#][\s\t]+sourceMappingURL=.*?\*\/$/mg, '');
             res.sourcemap.file = file.relative;
             applySourceMap(file, res.sourcemap);
           }


### PR DESCRIPTION
The RegExp that removed the sourceMappingURL comment only looked for a comment on its own single line. That caused the RegExp not to match with Stylus option `compress: true` and the comment not to be removed since all output is on a single line.
That led to multiple sourceMappingURL comments being added with possibly wrong file names.
That caused Firefox Developer Tools to ignore source maps if the first sourceMappingURL was wrong.
The updated RegExp will not match at the beginning of a line, instead it will match any characters, non greedy, until end of comment.
