### PR TITLE
Raw globals

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,12 @@ module.exports = function (options) {
       opts.sourcemap = assign({basePath: file.base}, opts.sourcemap);
     }
     if (file.data) {
-      opts.define = file.data;
+      if (opts.rawGlobals) {
+        delete opts.rawGlobals;
+        opts.rawDefine = file.data;
+      } else {
+        opts.define = file.data;
+      }
     }
     opts.filename = file.path;
 

--- a/index.js
+++ b/index.js
@@ -31,13 +31,14 @@ module.exports = function (options) {
     }
     if (file.data) {
       if (opts.rawGlobals) {
-        delete opts.rawGlobals;
         opts.rawDefine = file.data;
       } else {
         opts.define = file.data;
       }
     }
     opts.filename = file.path;
+    
+    delete opts.rawGlobals;
 
     stylus.render(file.contents.toString(enc || 'utf-8'), opts)
       .catch(function(err) {

--- a/index.js
+++ b/index.js
@@ -13,9 +13,10 @@ function guErr(err) {
 }
 
 module.exports = function (options) {
-  var opts = assign({}, options);
-
   return through.obj(function (file, enc, cb) {
+    var opts = assign({}, options);
+    var rawGlobals = opts.rawGlobals || false;
+    delete opts.rawGlobals;
 
     if (file.isStream()) {
       return cb(guErr('Streaming not supported'));
@@ -30,15 +31,9 @@ module.exports = function (options) {
       opts.sourcemap = assign({basePath: file.base}, opts.sourcemap);
     }
     if (file.data) {
-      if (opts.rawGlobals) {
-        opts.rawDefine = file.data;
-      } else {
-        opts.define = file.data;
-      }
+      opts[rawGlobals ? 'rawDefine' : 'define'] = file.data;
     }
     opts.filename = file.path;
-    
-    delete opts.rawGlobals;
 
     stylus.render(file.contents.toString(enc || 'utf-8'), opts)
       .catch(function(err) {


### PR DESCRIPTION
See #151, stylus/stylus#1286

Currenty `file.data` cannot be used for object variables, since they are treated by pairs of `(key, value)` by stylus.

This patch adds `rawGlobals` option, that changes how `file.data` is treated. When this option is set, `rawDefine` property is get set instead of `define`.

The option is deleted after it has been used.